### PR TITLE
fix(shell): 修复shell命令格式

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -10,7 +10,7 @@ find . -name \*.md  -exec markdownlint {} \; 2>msg.log
 
 echo "=================================================================="
 
-if [-e msg.log]; then
+if [ -e msg.log ]; then
   if grep -q "MD0" msg.log; then
     cat msg.log
     exit 1


### PR DESCRIPTION
修复if [-e错误

在if和[]中添加空格